### PR TITLE
Fix code scanning alert no. 19: Incorrect conversion between integer types

### DIFF
--- a/app/service/idgen/client/idgen_client2.go
+++ b/app/service/idgen/client/idgen_client2.go
@@ -2,7 +2,7 @@
  * WARNING! All changes made in this file will be lost!
  * Created from 'scheme.tl' by 'mtprotoc'
  *
- * Copyright (c) 2021-present,  Teamgram Studio (https://teamgram.io).
+Copyright (c) 2021-present,  Teamgram Studio (https://teamgram.io).
  *  All rights reserved.
  *
  * Author: teamgramio (teamgram.io@gmail.com)
@@ -13,6 +13,7 @@ package idgen_client
 import (
 	"context"
 	"strconv"
+	"math"
 
 	"github.com/teamgram/proto/mtproto"
 	"github.com/teamgram/teamgram-server/app/service/idgen/idgen"
@@ -204,7 +205,13 @@ func (m *IDGenClient2) NextChannelNPtsId(ctx context.Context, key int64, n int) 
 }
 
 func (m *IDGenClient2) CurrentChannelPtsId(ctx context.Context, key int64) (seq int32) {
-	seq = int32(m.getCurrentSeqId(ctx, channelPtsUpdatesNgenId+strconv.FormatInt(key, 10)))
+	seq64 := m.getCurrentSeqId(ctx, channelPtsUpdatesNgenId+strconv.FormatInt(key, 10))
+	if seq64 > math.MaxInt32 || seq64 < math.MinInt32 {
+		logx.WithContext(ctx).Errorf("idgen.getCurrentSeqId - value out of int32 range: %d", seq64)
+		seq = 0 // or handle the error as appropriate
+	} else {
+		seq = int32(seq64)
+	}
 	return
 }
 


### PR DESCRIPTION
Fixes [https://github.com/offsoc/teamgram-server/security/code-scanning/19](https://github.com/offsoc/teamgram-server/security/code-scanning/19)

To fix the problem, we need to ensure that the conversion from a 64-bit integer to a 32-bit integer is safe. This involves checking that the value fits within the `int32` range before performing the conversion. If the value exceeds the `int32` range, we should handle it appropriately, either by clamping the value to the maximum/minimum `int32` value or by returning an error/default value.

The best way to fix this is to add bounds checking before the conversion. Specifically, we should check if the value is within the range of `math.MinInt32` to `math.MaxInt32` before casting it to `int32`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
