### PR TITLE
Fix code scanning alert no. 17: Incorrect conversion between integer types

### DIFF
--- a/app/service/idgen/client/idgen_client2.go
+++ b/app/service/idgen/client/idgen_client2.go
@@ -172,7 +172,12 @@ func (m *IDGenClient2) NextNPtsId(ctx context.Context, key int64, n int) (seq in
 }
 
 func (m *IDGenClient2) CurrentPtsId(ctx context.Context, key int64) (seq int32) {
-	seq = int32(m.getCurrentSeqId(ctx, ptsUpdatesNgenId+strconv.FormatInt(key, 10)))
+	id := m.getCurrentSeqId(ctx, ptsUpdatesNgenId+strconv.FormatInt(key, 10))
+	if id > math.MaxInt32 || id < math.MinInt32 {
+		logx.WithContext(ctx).Errorf("idgen.getCurrentSeqId - value out of int32 range: %d", id)
+		return 0 // or handle the error as appropriate
+	}
+	seq = int32(id)
 	return
 }
 


### PR DESCRIPTION
Fixes [https://github.com/offsoc/teamgram-server/security/code-scanning/17](https://github.com/offsoc/teamgram-server/security/code-scanning/17)

To fix the problem, we need to ensure that the conversion from a 64-bit integer to a 32-bit integer is safe. This involves checking that the value is within the bounds of a 32-bit integer before performing the conversion. If the value is out of bounds, we should handle it appropriately, either by returning a default value or by raising an error.

The best way to fix this without changing existing functionality is to add bounds checking before the conversion. Specifically, we should check if the value is within the range of `math.MinInt32` to `math.MaxInt32` before converting it to `int32`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
