### PR TITLE
Fix code scanning alert no. 16: Incorrect conversion between integer types

### DIFF
--- a/app/service/idgen/client/idgen_client2.go
+++ b/app/service/idgen/client/idgen_client2.go
@@ -139,7 +139,12 @@ func (m *IDGenClient2) NextChannelMessageBoxId(ctx context.Context, key int64) (
 }
 
 func (m *IDGenClient2) CurrentChannelMessageBoxId(ctx context.Context, key int64) (seq int32) {
-	seq = int32(m.getCurrentSeqId(ctx, channelMessageBoxNgenId+strconv.FormatInt(key, 10)))
+	id := m.getCurrentSeqId(ctx, channelMessageBoxNgenId+strconv.FormatInt(key, 10))
+	if id > math.MaxInt32 || id < math.MinInt32 {
+		logx.WithContext(ctx).Errorf("idgen.getCurrentSeqId - value out of int32 range: %d", id)
+		return 0 // or handle the error as appropriate
+	}
+	seq = int32(id)
 	return
 }
 
@@ -153,7 +158,12 @@ func (m *IDGenClient2) NextSeqId(ctx context.Context, key int64) (seq int64) {
 }
 
 func (m *IDGenClient2) CurrentSeqId(ctx context.Context, key int64) (seq int32) {
-	seq = int32(m.getCurrentSeqId(ctx, seqUpdatesNgenId+strconv.FormatInt(key, 10)))
+	id := m.getCurrentSeqId(ctx, seqUpdatesNgenId+strconv.FormatInt(key, 10))
+	if id > math.MaxInt32 || id < math.MinInt32 {
+		logx.WithContext(ctx).Errorf("idgen.getCurrentSeqId - value out of int32 range: %d", id)
+		return 0 // or handle the error as appropriate
+	}
+	seq = int32(id)
 	return
 }
 


### PR DESCRIPTION
Fixes [https://github.com/offsoc/teamgram-server/security/code-scanning/16](https://github.com/offsoc/teamgram-server/security/code-scanning/16)

To fix the problem, we need to ensure that the 64-bit integer returned by `m.getCurrentSeqId` is within the bounds of a 32-bit integer before casting it to `int32`. This can be achieved by adding a bounds check before the conversion. If the value exceeds the `int32` range, we should handle it appropriately, such as by returning a default value or an error.

1. Add bounds checking for the conversion from `int64` to `int32`.
2. Ensure that the value is within the `int32` range before performing the cast.
3. Update the relevant functions in `app/service/idgen/client/idgen_client2.go`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
