### PR TITLE
Fix code scanning alert no. 13: Incorrect conversion between integer types

### DIFF
--- a/app/service/dfs/internal/core/dfs.uploadThemeFile_handler.go
+++ b/app/service/dfs/internal/core/dfs.uploadThemeFile_handler.go
@@ -167,7 +167,12 @@ func (c *DfsCore) DfsUploadThemeFile(in *dfs.TLDfsUploadThemeFile) (*mtproto.Doc
 		Date:          int32(time.Now().Unix()),
 		MimeType:      in.GetMimeType(),
 		Size2:         fileInfo.GetFileSize(),
-		Size2_INT32:   int32(fileInfo.GetFileSize()),
+		Size2_INT32:   func(size int64) int32 {
+			if size > math.MaxInt32 {
+				return math.MaxInt32
+			}
+			return int32(size)
+		}(fileInfo.GetFileSize()),
 		Size2_INT64:   fileInfo.GetFileSize(),
 		Thumbs:        thumbSizeList,
 		VideoThumbs:   nil,

--- a/app/service/dfs/internal/dao/dfs_file_info.go
+++ b/app/service/dfs/internal/dao/dfs_file_info.go
@@ -81,17 +81,17 @@ func (d *Dao) GetFileInfo(ctx context.Context, ownerId, fileId int64) (fileInfo 
 		case "file_name":
 			fileInfo.FileName = v
 		case "file_total_parts":
-			fileTotalParts, _ := strconv.Atoi(v)
-			fileInfo.FileTotalParts = fileTotalParts
+			fileTotalParts, _ := strconv.ParseInt(v, 10, 32)
+			fileInfo.FileTotalParts = int(fileTotalParts)
 		case "first_file_part_size":
-			firstFilePartSize, _ := strconv.Atoi(v)
-			fileInfo.FirstFilePartSize = firstFilePartSize
+			firstFilePartSize, _ := strconv.ParseInt(v, 10, 32)
+			fileInfo.FirstFilePartSize = int(firstFilePartSize)
 		case "file_part_size":
-			filePartSize, _ := strconv.Atoi(v)
-			fileInfo.FilePartSize = filePartSize
+			filePartSize, _ := strconv.ParseInt(v, 10, 32)
+			fileInfo.FilePartSize = int(filePartSize)
 		case "last_file_part_size":
-			lastFilePartSize, _ := strconv.Atoi(v)
-			fileInfo.LastFilePartSize = lastFilePartSize
+			lastFilePartSize, _ := strconv.ParseInt(v, 10, 32)
+			fileInfo.LastFilePartSize = int(lastFilePartSize)
 		case "mtime":
 			fileInfo.Mtime, _ = strconv.ParseInt(v, 10, 64)
 		}


### PR DESCRIPTION
Fixes [https://github.com/offsoc/teamgram-server/security/code-scanning/13](https://github.com/offsoc/teamgram-server/security/code-scanning/13)

To fix the problem, we need to ensure that the value being converted to `int32` is within the bounds of `int32`. This can be done by using `strconv.ParseInt` with a bit size of 32, which will directly parse the string into a 32-bit integer, or by adding explicit bounds checking before the conversion.

1. Replace the use of `strconv.Atoi` with `strconv.ParseInt` specifying a 32-bit size.
2. Ensure that any conversion from a larger integer type to `int32` includes bounds checking to prevent overflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
