### PR TITLE
Fix code scanning alert no. 18: Incorrect conversion between integer types

### DIFF
--- a/app/service/idgen/client/idgen_client2.go
+++ b/app/service/idgen/client/idgen_client2.go
@@ -201,7 +201,12 @@ func (m *IDGenClient2) NextQtsId(ctx context.Context, key int64) (seq int32) {
 }
 
 func (m *IDGenClient2) CurrentQtsId(ctx context.Context, key int64) (seq int32) {
-	seq = int32(m.getCurrentSeqId(ctx, qtsUpdatesNgenId+strconv.FormatInt(key, 10)))
+	id := m.getCurrentSeqId(ctx, qtsUpdatesNgenId+strconv.FormatInt(key, 10))
+	if id > math.MaxInt32 || id < math.MinInt32 {
+		logx.WithContext(ctx).Errorf("idgen.getCurrentSeqId - value out of int32 range: %d", id)
+		return 0 // or handle the error as appropriate
+	}
+	seq = int32(id)
 	return
 }
 


### PR DESCRIPTION
Fixes [https://github.com/offsoc/teamgram-server/security/code-scanning/18](https://github.com/offsoc/teamgram-server/security/code-scanning/18)

To fix the problem, we need to ensure that the conversion from `int64` to `int32` is safe by adding bounds checks before performing the conversion. This will prevent any unexpected values if the `int64` value exceeds the range of `int32`.

- We will add checks to ensure the `int64` value is within the `int32` range before converting it.
- If the value is out of range, we will log an error and handle it appropriately (e.g., returning a default value or an error).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
