### PR TITLE
Fix code scanning alert no. 4: Incorrect conversion between integer types

### DIFF
--- a/app/bff/qrcode/internal/dao/redis_qr_login.go
+++ b/app/bff/qrcode/internal/dao/redis_qr_login.go
@@ -21,6 +21,7 @@ package dao
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/teamgram/teamgram-server/app/bff/qrcode/internal/model"
@@ -63,8 +64,13 @@ func (d *Dao) GetCacheQRLoginCode(ctx context.Context, keyId int64) (code *model
 		case "server_id":
 			code.ServerId = v
 		case "api_id":
-			v, _ := strconv.ParseInt(v, 10, 64)
-			code.ApiId = int32(v)
+			v, _ := strconv.ParseInt(v, 10, 32)
+			if v < math.MinInt32 || v > math.MaxInt32 {
+				logx.WithContext(ctx).Errorf("value out of int32 range: %d", v)
+				code.ApiId = 0 // or handle the error as appropriate
+			} else {
+				code.ApiId = int32(v)
+			}
 		case "api_hash":
 			code.ApiHash = v
 		case "code_hash":


### PR DESCRIPTION
Fixes [https://github.com/offsoc/teamgram-server/security/code-scanning/4](https://github.com/offsoc/teamgram-server/security/code-scanning/4)

To fix the problem, we need to ensure that the value parsed from the string is within the bounds of a 32-bit integer before converting it. This can be done by adding a bounds check after parsing the integer. If the value is within the acceptable range, we can safely convert it to a 32-bit integer. Otherwise, we should handle the error appropriately.

- Use `strconv.ParseInt` to parse the integer with a 32-bit size.
- Add a bounds check to ensure the parsed value is within the range of a 32-bit integer.
- If the value is out of bounds, handle the error (e.g., by logging it or setting a default value).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
