### PR TITLE
Fix code scanning alert no. 6: Incorrect conversion between integer types

### DIFF
--- a/app/service/authsession/internal/dao/auth_key.go
+++ b/app/service/authsession/internal/dao/auth_key.go
@@ -23,6 +23,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/teamgram/marmota/pkg/stores/sqlc"
@@ -70,8 +71,12 @@ func (d *Dao) getAuthKey(ctx context.Context, keyId int64) (keyData *mtproto.Aut
 	for k, v := range values {
 		switch k {
 		case "auth_key_type":
-			authKeyType, _ := strconv.Atoi(v)
-			keyData.AuthKeyType = int32(authKeyType)
+			parsed, err := strconv.ParseInt(v, 10, 32)
+			if err != nil || parsed < math.MinInt32 || parsed > math.MaxInt32 {
+				logx.WithContext(ctx).Errorf("Invalid auth_key_type value: %v", v)
+				return nil, fmt.Errorf("invalid auth_key_type value: %v", v)
+			}
+			keyData.AuthKeyType = int32(parsed)
 		case "auth_key_id":
 			keyData.AuthKeyId, _ = strconv.ParseInt(v, 10, 64)
 		case "auth_key":


### PR DESCRIPTION
Fixes [https://github.com/offsoc/teamgram-server/security/code-scanning/6](https://github.com/offsoc/teamgram-server/security/code-scanning/6)

To fix the problem, we should replace the use of `strconv.Atoi` with `strconv.ParseInt`, specifying the bit size as 32. This ensures that the parsed value is within the range of `int32`. Additionally, we should add bounds checking to ensure the value does not exceed the limits of `int32`.

- Replace `strconv.Atoi` with `strconv.ParseInt` specifying a bit size of 32.
- Add bounds checking to ensure the parsed value is within the `int32` range.
- Update the relevant lines in the file `app/service/authsession/internal/dao/auth_key.go`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
