### PR TITLE
Fix code scanning alert no. 5: Incorrect conversion between integer types

### DIFF
--- a/app/bff/qrcode/internal/dao/redis_qr_login.go
+++ b/app/bff/qrcode/internal/dao/redis_qr_login.go
@@ -80,8 +80,13 @@ func (d *Dao) GetCacheQRLoginCode(ctx context.Context, keyId int64) (code *model
 		case "user_id":
 			code.UserId, _ = strconv.ParseInt(v, 10, 64)
 		case "state":
-			v, _ := strconv.ParseInt(v, 10, 64)
-			code.State = int(v)
+			v, _ := strconv.ParseInt(v, 10, 32)
+			if v < math.MinInt32 || v > math.MaxInt32 {
+				logx.WithContext(ctx).Errorf("value out of int range: %d", v)
+				code.State = 0 // or handle the error as appropriate
+			} else {
+				code.State = int(v)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes [https://github.com/offsoc/teamgram-server/security/code-scanning/5](https://github.com/offsoc/teamgram-server/security/code-scanning/5)

To fix the problem, we need to ensure that the conversion from a 64-bit integer to an `int` type is safe. This can be done by checking if the parsed value fits within the bounds of the `int` type before performing the conversion. If the value is out of bounds, we should handle the error appropriately, such as by logging an error message and setting a default value.

1. Use `strconv.ParseInt` with a bit size of 32 for the `state` field, as it is being converted to an `int` type.
2. Add bounds checking to ensure the parsed value fits within the range of the `int` type before converting.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
