### PR TITLE
Fix code scanning alert no. 228: Incorrect conversion between integer types

### DIFF
--- a/app/service/idgen/client/idgen_client2.go
+++ b/app/service/idgen/client/idgen_client2.go
@@ -13,6 +13,7 @@ package idgen_client
 import (
 	"context"
 	"strconv"
+	"math"
 
 	"github.com/teamgram/proto/mtproto"
 	"github.com/teamgram/teamgram-server/app/service/idgen/idgen"
@@ -180,12 +181,22 @@ func (m *IDGenClient2) SetCurrentPtsId(ctx context.Context, key int64, v int32) 
 }
 
 func (m *IDGenClient2) NextQtsId(ctx context.Context, key int64) (seq int32) {
-	seq = int32(m.getNextSeqId(ctx, qtsUpdatesNgenId+strconv.FormatInt(key, 10)))
+	seq64 := m.getNextSeqId(ctx, qtsUpdatesNgenId+strconv.FormatInt(key, 10))
+	if seq64 > math.MaxInt32 || seq64 < math.MinInt32 {
+		logx.WithContext(ctx).Errorf("NextQtsId - value out of int32 range: %d", seq64)
+		return 0 // or handle the error appropriately
+	}
+	seq = int32(seq64)
 	return
 }
 
 func (m *IDGenClient2) CurrentQtsId(ctx context.Context, key int64) (seq int32) {
-	seq = int32(m.getCurrentSeqId(ctx, qtsUpdatesNgenId+strconv.FormatInt(key, 10)))
+	seq64 := m.getCurrentSeqId(ctx, qtsUpdatesNgenId+strconv.FormatInt(key, 10))
+	if seq64 > math.MaxInt32 || seq64 < math.MinInt32 {
+		logx.WithContext(ctx).Errorf("CurrentQtsId - value out of int32 range: %d", seq64)
+		return 0 // or handle the error appropriately
+	}
+	seq = int32(seq64)
 	return
 }
 


### PR DESCRIPTION
Fixes [https://github.com/offsoc/teamgram-server/security/code-scanning/228](https://github.com/offsoc/teamgram-server/security/code-scanning/228)

To fix the problem, we need to ensure that the conversion from a 64-bit integer to a 32-bit integer is safe. This can be done by adding bounds checks before performing the conversion. Specifically, we should check if the value is within the range of a 32-bit integer (`math.MinInt32` to `math.MaxInt32`) before converting it.

1. Import the `math` package to access the constants for the minimum and maximum values of a 32-bit integer.
2. Add bounds checks before converting the 64-bit integer to a 32-bit integer.
3. If the value is out of bounds, handle it appropriately (e.g., return a default value or an error).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
